### PR TITLE
Make username lower

### DIFF
--- a/sshapiauthenticator/auth.py
+++ b/sshapiauthenticator/auth.py
@@ -47,7 +47,7 @@ class SSHAPIAuthenticator(Authenticator):
 
         Return None otherwise.
         """
-        username = data['username']
+        username = data['username'].lower()
         pwd = data['password']
         try:
             if self.skey!='':


### PR DESCRIPTION
This fixes the case where the user uses upper cases characters to log in.