### PR TITLE
Add tests via pytest, asynctest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.sublime-*
 *.pyc
 *.egg-info
+.coverage
+.pytest_cache/
+htmlcov/
+**/.DS_Store

--- a/README.md
+++ b/README.md
@@ -9,9 +9,17 @@ Use with [SSH Spawner](https://github.com/NERSC/SSHSpawner) to authenticate to r
 Requires Python 3
 
 ```
-python setup.py install 
+python setup.py install
 ```
 
 ## Configuration
 
 See [jupyterhub_config.py](jupyterhub_config.py) for a sample configuration
+
+## Testing
+
+In whatever environment you wish to run the tests, run `pip install -r test_requirements.txt`.
+
+If you have [pipenv](https://github.com/pypa/pipenv) installed, you can run `pipenv install -r test_requirements.txt` to create an environment and do the installations in one step.
+
+Then in that environment run `pytest --cov-report html --cov=sshapiauthenticator` from the project root directory to run the tests and generate a coverage report.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:warnings

--- a/sshapiauthenticator/auth.py
+++ b/sshapiauthenticator/auth.py
@@ -1,11 +1,10 @@
 import os
+import json
+from pathlib import Path
+from subprocess import check_output
 
 from traitlets import Unicode, Integer
 from tornado import httpclient, httputil
-import json
-from subprocess import check_output
-
-
 from jupyterhub.auth import Authenticator
 
 
@@ -31,13 +30,13 @@ class SSHAPIAuthenticator(Authenticator):
         with open(file, 'w') as f:
             f.write(data)
         os.chmod(file, 0o600)
-        out = check_output(["ssh-keygen","-f",file,'-y'])
-        with open(file+'.pub','w') as f:
+        out = check_output(['ssh-keygen', '-f', str(file), '-y'])
+        with open(f'{file}.pub', 'w') as f:
             f.write(str(out, 'utf-8'))
         for line in data.split('\n'):
-          if line.startswith('ssh-rsa-cert'):
-            with open(file+'-cert.pub', 'w') as f:
-                f.write(line)
+            if line.startswith('ssh-rsa-cert'):
+                with open(f'{file}-cert.pub', 'w') as f:
+                    f.write(line)
 
     async def authenticate(self, handler, data):
         """Authenticate with SSH Auth API, and return the private key
@@ -49,9 +48,9 @@ class SSHAPIAuthenticator(Authenticator):
         pwd = data['password']
         try:
             request = httpclient.AsyncHTTPClient()
-            if self.skey!='':
+            if self.skey != '':
                 headers = httputil.HTTPHeaders({'content-type': 'application/json'})
-                body = json.dumps({'skey':self.skey})
+                body = json.dumps({'skey': self.skey})
                 resp = await request.fetch(self.server,
                                            raise_error=False,
                                            method='POST',
@@ -67,7 +66,7 @@ class SSHAPIAuthenticator(Authenticator):
                                            auth_username=username,
                                            auth_password=pwd)
             if resp.code == 200:
-                file = '%s/%s.key' % (self.cert_path, username)
+                file = Path(self.cert_path) / f'{username}.key'
                 self._write_key(file, resp.body.decode('utf-8'))
             else:
                 self.log.warning("SSH Auth API Authentication failed (%s@%s):",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,5 @@
+jupyterhub
+pytest
+pytest-cov
+pytest-asyncio
+asynctest

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1,0 +1,97 @@
+import pytest
+from asynctest import patch, Mock, CoroutineMock
+import sys, os, pathlib, subprocess
+# Enable importing of the module to be tested
+test_dir = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
+root_dir = test_dir.parent
+sys.path.append(str(root_dir))
+from sshapiauthenticator.auth import SSHAPIAuthenticator
+
+@pytest.fixture(scope='module')
+def ssh_key():
+    # These calls will generate local files
+    subprocess.call(['ssh-keygen', '-t', 'rsa', '-N', '', '-C', 'ca@localhost', '-f', 'ca'])
+    subprocess.call(['ssh-keygen', '-s', 'ca', '-h', '-I', 'localhost', 'ca.pub'])
+    skey = ''
+    with open('ca', 'r') as f:
+        skey += f.read()
+    with open('ca-cert.pub', 'r') as f:
+        skey += f.read()
+    # Clean up generated files
+    subprocess.call(['rm', 'ca', 'ca.pub', 'ca-cert.pub'])
+    return skey
+
+@pytest.mark.asyncio
+@patch('sshapiauthenticator.auth.httpclient', autospec=True)
+async def test_auth_nonempty_skey_valid_credentials(mock_httpclient, ssh_key):
+    async_client = mock_httpclient.AsyncHTTPClient.return_value
+    async_client.fetch = CoroutineMock(
+        return_value=Mock(**{'code': 200, 'body': ssh_key.encode('utf-8')})
+    )
+    authenticator = SSHAPIAuthenticator()
+    authenticator.server = 'http://localhost:9999'
+    authenticator.skey = 'non-empty'
+    data = {'username': 'tester', 'password': 'valid'}
+    resp = await authenticator.authenticate(None, data)
+    assert resp == 'tester'
+
+@pytest.mark.asyncio
+@patch('sshapiauthenticator.auth.httpclient', autospec=True)
+async def test_auth_no_skey_valid_credentials(mock_httpclient, ssh_key):
+    async_client = mock_httpclient.AsyncHTTPClient.return_value
+    async_client.fetch = CoroutineMock(
+        return_value=Mock(**{'code': 200, 'body': ssh_key.encode('utf-8')})
+    )
+    authenticator = SSHAPIAuthenticator()
+    authenticator.server = 'http://localhost:9999'
+    authenticator.skey = ''
+    data = {'username': 'tester', 'password': 'valid'}
+    resp = await authenticator.authenticate(None, data)
+    assert resp == 'tester'
+
+@pytest.mark.asyncio
+@patch('sshapiauthenticator.auth.httpclient', autospec=True)
+async def test_auth_no_skey_invalid_username_password(mock_httpclient):
+    async_client = mock_httpclient.AsyncHTTPClient.return_value
+    # Server sends 401: Unauthorized error code
+    async_client.fetch = CoroutineMock(
+        return_value=Mock(**{'code': 401})
+    )
+    authenticator = SSHAPIAuthenticator()
+    authenticator.server = 'http://localhost:9999'
+    authenticator.skey = ''
+    handler = Mock(**{'request': Mock(**{'remote_ip': 'http://localhost:9998'})})
+    data = {'username': 'tester', 'password': 'invalid'}
+    resp = await authenticator.authenticate(handler, data)
+    assert resp is None
+
+@pytest.mark.asyncio
+@patch('sshapiauthenticator.auth.httpclient', autospec=True)
+async def test_auth_exception_with_handler(mock_httpclient):
+    async_client = mock_httpclient.AsyncHTTPClient.return_value
+    # No body, so _write_key will raise exception
+    async_client.fetch = CoroutineMock(
+        return_value=Mock(**{'code': 200})
+    )
+    authenticator = SSHAPIAuthenticator()
+    authenticator.server = 'http://localhost:9999'
+    authenticator.skey = ''
+    handler = Mock(**{'request': Mock(**{'remote_ip': 'http://localhost:9998'})})
+    data = {'username': 'tester', 'password': 'valid'}
+    resp = await authenticator.authenticate(handler, data)
+    assert resp is None
+
+@pytest.mark.asyncio
+@patch('sshapiauthenticator.auth.httpclient', autospec=True)
+async def test_auth_exception_no_handler(mock_httpclient):
+    async_client = mock_httpclient.AsyncHTTPClient.return_value
+    # No body, so _write_key will raise exception
+    async_client.fetch = CoroutineMock(
+        return_value=Mock(**{'code': 200})
+    )
+    authenticator = SSHAPIAuthenticator()
+    authenticator.server = 'http://localhost:9999'
+    authenticator.skey = ''
+    data = {'username': 'tester', 'password': 'valid'}
+    resp = await authenticator.authenticate(None, data)
+    assert resp is None

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1,11 +1,60 @@
 import pytest
 from asynctest import patch, Mock, CoroutineMock
-import sys, os, pathlib, subprocess
+import sys, os, subprocess
+from pathlib import Path
 # Enable importing of the module to be tested
-test_dir = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
+test_dir = Path(os.path.dirname(os.path.realpath(__file__)))
 root_dir = test_dir.parent
 sys.path.append(str(root_dir))
 from sshapiauthenticator.auth import SSHAPIAuthenticator
+
+def get_file(filepath):
+    if os.path.exists(filepath):
+        with open(filepath, 'r') as f:
+            return f.read()
+    return None
+
+def keypath(username, cert_path):
+    return str(Path(cert_path)/f'{username}.key')
+
+def assert_valid_keys_exist(ssh_key, username='tester', cert_path='/tmp/', encoding='utf8'):
+    key = keypath(username, cert_path)
+    assert get_file(key) == ssh_key
+    public_key = subprocess.check_output(['ssh-keygen', '-f', key, '-y'])
+    assert get_file(f'{key}.pub') == public_key.decode(encoding)
+    assert get_file(f'{key}-cert.pub') == ssh_key[ssh_key.find('ssh-rsa-cert'):]
+
+def assert_keys_do_not_exist(username='tester', cert_path='/tmp/'):
+    key = keypath(username, cert_path)
+    assert get_file(key) is None
+    assert get_file(f'{key}.pub') is None
+    assert get_file(f'{key}-cert.pub') is None
+
+@pytest.fixture(autouse=True)
+def cleaner():
+    """If a test uses a different username and cert_path, it should call
+    cleaner.config(username, cert_path) before exiting"""
+    class Cleaner():
+        def __init__(self):
+            self.username = 'tester'
+            self.cert_path = '/tmp/'
+
+        def config(self, username, cert_path):
+            self.username = username
+            self.cert_path = cert_path
+
+        def remove_files(self):
+            key = keypath(self.username, self.cert_path)
+            public_key = f'{key}.pub'
+            cert = f'{key}-cert.pub'
+            for file in [key, public_key, cert]:
+                try:
+                    os.remove(file)
+                except FileNotFoundError as e:
+                    pass
+    cleaner = Cleaner()
+    yield cleaner
+    cleaner.remove_files()
 
 @pytest.fixture(scope='module')
 def ssh_key():
@@ -26,72 +75,117 @@ def ssh_key():
 async def test_auth_nonempty_skey_valid_credentials(mock_httpclient, ssh_key):
     async_client = mock_httpclient.AsyncHTTPClient.return_value
     async_client.fetch = CoroutineMock(
-        return_value=Mock(**{'code': 200, 'body': ssh_key.encode('utf-8')})
+        return_value=Mock(
+            spec=['code', 'body'],
+            **{'code': 200, 'body': ssh_key.encode('utf8')},
+        )
     )
     authenticator = SSHAPIAuthenticator()
     authenticator.server = 'http://localhost:9999'
     authenticator.skey = 'non-empty'
-    data = {'username': 'tester', 'password': 'valid'}
+    username = 'tester'
+    data = {'username': username, 'password': 'valid'}
+    assert_keys_do_not_exist()
     resp = await authenticator.authenticate(None, data)
-    assert resp == 'tester'
+    assert_valid_keys_exist(ssh_key)
+    assert resp == username
 
 @pytest.mark.asyncio
 @patch('sshapiauthenticator.auth.httpclient', autospec=True)
 async def test_auth_no_skey_valid_credentials(mock_httpclient, ssh_key):
     async_client = mock_httpclient.AsyncHTTPClient.return_value
     async_client.fetch = CoroutineMock(
-        return_value=Mock(**{'code': 200, 'body': ssh_key.encode('utf-8')})
+        return_value=Mock(
+            spec=['code', 'body'],
+            **{'code': 200, 'body': ssh_key.encode('utf8')},
+        )
     )
     authenticator = SSHAPIAuthenticator()
     authenticator.server = 'http://localhost:9999'
     authenticator.skey = ''
-    data = {'username': 'tester', 'password': 'valid'}
+    username = 'tester'
+    data = {'username': username, 'password': 'valid'}
+    assert_keys_do_not_exist()
     resp = await authenticator.authenticate(None, data)
-    assert resp == 'tester'
+    assert_valid_keys_exist(ssh_key)
+    assert resp == username
 
 @pytest.mark.asyncio
 @patch('sshapiauthenticator.auth.httpclient', autospec=True)
-async def test_auth_no_skey_invalid_username_password(mock_httpclient):
+async def test_auth_no_skey_invalid_username_password(mock_httpclient, caplog):
     async_client = mock_httpclient.AsyncHTTPClient.return_value
     # Server sends 401: Unauthorized error code
     async_client.fetch = CoroutineMock(
-        return_value=Mock(**{'code': 401})
+        return_value=Mock(
+            spec=['code', 'reason'],
+            **{'code': 401, 'reason': 'Unauthorized'},
+        )
     )
     authenticator = SSHAPIAuthenticator()
     authenticator.server = 'http://localhost:9999'
     authenticator.skey = ''
-    handler = Mock(**{'request': Mock(**{'remote_ip': 'http://localhost:9998'})})
+    handler = Mock(**{'request': Mock(**{'remote_ip': 'localhost'})})
     data = {'username': 'tester', 'password': 'invalid'}
+    assert_keys_do_not_exist()
     resp = await authenticator.authenticate(handler, data)
+    assert_keys_do_not_exist()
     assert resp is None
+    logs = caplog.record_tuples
+    assert len(logs) == 1
+    _, _, message = logs[0]
+    expected_message = (
+        'SSH Auth API Authentication failed for tester@localhost'
+        ' with error 401: "Unauthorized"'
+    )
+    assert message == expected_message
 
 @pytest.mark.asyncio
 @patch('sshapiauthenticator.auth.httpclient', autospec=True)
-async def test_auth_exception_with_handler(mock_httpclient):
+async def test_auth_exception_with_handler(mock_httpclient, caplog):
     async_client = mock_httpclient.AsyncHTTPClient.return_value
     # No body, so _write_key will raise exception
     async_client.fetch = CoroutineMock(
-        return_value=Mock(**{'code': 200})
+        return_value=Mock(
+            spec=['code'],
+            **{'code': 200},
+        )
     )
     authenticator = SSHAPIAuthenticator()
     authenticator.server = 'http://localhost:9999'
     authenticator.skey = ''
-    handler = Mock(**{'request': Mock(**{'remote_ip': 'http://localhost:9998'})})
+    handler = Mock(**{'request': Mock(**{'remote_ip': 'localhost'})})
     data = {'username': 'tester', 'password': 'valid'}
+    assert_keys_do_not_exist()
     resp = await authenticator.authenticate(handler, data)
+    assert_keys_do_not_exist()
     assert resp is None
+    logs = caplog.record_tuples
+    assert len(logs) == 1
+    _, _, message = logs[0]
+    expected_message = 'SSH Auth API Authentication failed for tester@localhost'
+    assert message == expected_message
 
 @pytest.mark.asyncio
 @patch('sshapiauthenticator.auth.httpclient', autospec=True)
-async def test_auth_exception_no_handler(mock_httpclient):
+async def test_auth_exception_no_handler(mock_httpclient, caplog):
     async_client = mock_httpclient.AsyncHTTPClient.return_value
     # No body, so _write_key will raise exception
     async_client.fetch = CoroutineMock(
-        return_value=Mock(**{'code': 200})
+        return_value=Mock(
+            spec=['code'],
+            **{'code': 200},
+        )
     )
     authenticator = SSHAPIAuthenticator()
     authenticator.server = 'http://localhost:9999'
     authenticator.skey = ''
     data = {'username': 'tester', 'password': 'valid'}
+    assert_keys_do_not_exist()
     resp = await authenticator.authenticate(None, data)
+    assert_keys_do_not_exist()
     assert resp is None
+    logs = caplog.record_tuples
+    assert len(logs) == 1
+    _, _, message = logs[0]
+    expected_message = 'SSH Auth API Authentication failed for user "tester"'
+    assert message == expected_message


### PR DESCRIPTION
Currently these tests do not necessarily represent server behavior faithfully, but they do achieve 100% coverage of `sshapiauthenticator/auth.py`. 

They also demonstrate one straightforward means of mocking out asynchronous network code.

There may be a cleaner method of generating a valid ssh key without calling `ssh-keygen` via `subprocess`. Although the method currently used will produce temporary files on the user's system, it also removes them.